### PR TITLE
Add some context-dependence to Control

### DIFF
--- a/Support/Symbol List.tmPreferences
+++ b/Support/Symbol List.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>
+        source.debian.changelog meta.version-number,
+        source.debian.control keyword.control
+    </string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>

--- a/Syntaxes/debian-changelog.sublime-syntax
+++ b/Syntaxes/debian-changelog.sublime-syntax
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-# See http://www.sublimetext.com/docs/3/syntax.html
+# See http://www.sublimetext.com/docs/syntax.html
 name: changelog (Debian)
 file_extensions:
   - changelog
@@ -9,30 +9,84 @@ scope: source.debian.changelog
 
 contexts:
   main:
-    - include: changelog-header
-    - include: changelog-footer
+    - include: header
+
+  header:
+    - match: ^[\w-]+
+      scope: entity.name.class.debian.changelog
+      push: [body, header-annotations]
+
+  header-annotations:
+    - match: \(
+      scope: punctuation.section.group.begin.debian.changelog
+      push:
+        - meta_scope: meta.version-number.debian.changelog
+                      meta.parens.debian.changelog
+        - include: debian-common.sublime-syntax#semantic-version
+        - match: \)
+          scope: punctuation.section.group.end.debian.changelog
+          pop: true
+        - include: debian-common.sublime-syntax#pop-eol
+    - match: \b(?:un)?stable
+      scope: constant.language.debian.changelog
+    - match: ;
+      scope: punctuation.separator.sequence.debian.changelog
+    - match: (\S+)(=)(\S+)
+      captures:
+        1: meta.mapping.key.debian.changelog
+        2: punctuation.separator.mapping.key-value.debian.changelog
+        3: meta.mapping.value.debian.changelog
+           string.unquoted.debian.changelog
+    - include: debian-common.sublime-syntax#pop-eol
+
+  body:
+    - meta_scope: meta.block.version.debian.changelog
+    - match: ^[ \t]+(?=\[)
+      push:
+        - meta_content_scope: meta.annotation.debian.changelog
+                              string.quoted.other.debian.changelog
+        - match: \[
+          scope: punctuation.definition.annotation.begin.debian.changelog
+        # The `string` scope is a workaround for a ST3xxx bug
+        - match: \]
+          scope: string.quoted.other.debian.changelog
+                 punctuation.definition.annotation.end.debian.changelog
+          pop: true
+        - include: debian-common.sublime-syntax#pop-eol
     - include: content-close-bug
     - include: content-code-span
+    - include: debian-common.sublime-syntax#url
+    - match: ^[ \t]{2,}([*+-])
+      scope: punctuation.definition.list_item.debian.changelog
+    - match: (?=^ --)
+      set: footer
 
-  changelog-header:
-    - match: (.+) [(](.+)[)] (.+); (.+)
+  footer:
+    - meta_scope: meta.block.version.debian.changelog
+    - match: ^ (--)
       captures:
-        1: keyword.control.debian
-        2: support.function.debian
-        3: support.class.debian
-        4: support.constant.debian
-
-  changelog-footer:
-    - match: ' (--) (.+) (<.+@.+[.].+>|<.+?at.+?dot.+?>)  (.+)'
-      captures:
-        1: comment.line.debian
-        2: markup.italic.debian
-        3: variable.language.debian
-        4: string.unquoted.debian
+        1: punctuation.section.block.begin.debian.changelog
+      push:
+        - include: debian-common.sublime-syntax#email-address
+        - include: debian-common.sublime-syntax#date-iso
+        - include: debian-common.sublime-syntax#pop-eol
+      pop: true
 
   content-close-bug:
-    - match: '[Cc]loses:\s*(?:[Bb]ug)?\#?\s?\d+(?:,\s*(?:bug)?\#?\s?\d+)*'
-      scope: string.unquoted.debian
+    - match: (?=(?:[Cc]loses|LP):\s*(?:[Bb]ug|#\d))
+      push:
+        - match: ([Cc]loses|LP)(:)
+          captures:
+            1: meta.mapping.key.debian.changelog
+            2: punctuation.separator.mapping.key-value.debian.changelog
+        - match: ','
+          scope: punctuation.separator.sequence.debian.changelog
+        - match: (?:[Bb]ug)?\s*((#)(\d+))
+          captures:
+            1: meta.tag.issue.debian.changelog
+            2: punctuation.definition.debian.changelog
+            3: constant.numeric.integer.decimal.debian.changelog
+        - include: debian-common.sublime-syntax#else-pop
 
   content-code-span:
     - match: (`+)(?!`)

--- a/Syntaxes/debian-changelog.sublime-syntax
+++ b/Syntaxes/debian-changelog.sublime-syntax
@@ -10,6 +10,7 @@ scope: source.debian.changelog
 contexts:
   main:
     - include: header
+    - include: debian-common.sublime-syntax#comments
 
   header:
     - match: ^[\w-]+
@@ -27,8 +28,9 @@ contexts:
           scope: punctuation.section.group.end.debian.changelog
           pop: true
         - include: debian-common.sublime-syntax#pop-eol
-    - match: \b(?:un)?stable
+    - match: \b(?:(?:old){0,2}stable|testing|unstable|experimental)\b
       scope: constant.language.debian.changelog
+    - include: debian-common.sublime-syntax#debian-versions
     - match: ;
       scope: punctuation.separator.sequence.debian.changelog
     - match: (\S+)(=)(\S+)
@@ -70,7 +72,7 @@ contexts:
         - include: debian-common.sublime-syntax#email-address
         - include: debian-common.sublime-syntax#date-iso
         - include: debian-common.sublime-syntax#pop-eol
-      pop: true
+    - include: debian-common.sublime-syntax#pop-eol
 
   content-close-bug:
     - match: (?=(?:[Cc]loses|LP):\s*(?:[Bb]ug|#\d))

--- a/Syntaxes/debian-common.sublime-syntax
+++ b/Syntaxes/debian-common.sublime-syntax
@@ -26,6 +26,10 @@ contexts:
         - match: \n
           pop: true
 
+  debian-versions:
+    - match: (?:buzz|rex|bo|hamm|slink|potato|woody|sarge|etch|lenny|squeeze|wheezy|jessie|stretch|buster|bullseye)
+      scope: constant.language.debian
+
   email-address:
     # email reference
     - match: <(?=\S+?(?i:@|at)\S+?(?i:\.|dot)\S+?>)

--- a/Syntaxes/debian-common.sublime-syntax
+++ b/Syntaxes/debian-common.sublime-syntax
@@ -1,0 +1,75 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+name: Debian utility matches
+file_extensions: []
+scope: source.debian.common
+hidden: true
+
+contexts:
+  main:
+    - match: \b\B
+
+  comments:
+    - match: '#'
+      scope: punctuation.definition.comment.debian
+      push:
+        - meta_scope: comment.line.debian
+        - match: \n
+          pop: true
+
+  email-address:
+    # email reference
+    - match: <(?=\S+?(?i:@|at)\S+?(?i:\.|dot)\S+?>)
+      scope: punctuation.definition.reference.email.begin.debian
+      push: [email-meta, email-name]
+
+  email-meta:
+    - meta_scope: meta.reference.email.debian
+    - match: ''
+      pop: true
+
+  email-name:
+    - meta_content_scope: entity.name.reference.email.debian
+    - match: (?i:@|at)
+      scope: punctuation.separator.email.debian
+      set: email-domain
+    - include: email-end
+
+  email-domain:
+    - meta_content_scope: entity.name.reference.email.debian
+    - match: (?i:\.|dot)
+      scope: punctuation.separator.domain.debian
+    - include: email-end
+
+  email-end:
+    - match: '>'
+      scope: punctuation.definition.reference.email.end.debian
+      pop: true
+
+  url:
+    - match: https?://\S+
+      scope: markup.underline.link.debian
+
+  semantic-version:
+    - match: |-
+        (?x:
+          (\d+)
+          (?:(\.)(\d+)
+            (?:(\.)(\d+)
+              (?:(-|~)([\w.]+))?
+              (?:(\+)([\w.]+))?
+            )?
+          )?
+        )
+      scope: meta.number.version.debian
+      captures:
+        1: constant.numeric.integer.decimal.debian
+        2: punctuation.separator.sequence.debian
+        3: constant.numeric.integer.decimal.debian
+        4: punctuation.separator.sequence.debian
+        5: constant.numeric.integer.decimal.debian
+        6: punctuation.separator.sequence.debian
+        7: string.unquoted.debian
+        8: punctuation.separator.sequence.debian
+        9: string.unquoted.debian

--- a/Syntaxes/debian-common.sublime-syntax
+++ b/Syntaxes/debian-common.sublime-syntax
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-# See http://www.sublimetext.com/docs/3/syntax.html
+# See http://www.sublimetext.com/docs/syntax.html
 name: Debian utility matches
 file_extensions: []
 scope: source.debian.common
@@ -9,6 +9,14 @@ hidden: true
 contexts:
   main:
     - match: \b\B
+
+  pop-eol:
+    - match: (?=$|\n)
+      pop: true
+
+  else-pop:
+    - match: (?=\S)
+      pop: true
 
   comments:
     - match: '#'
@@ -50,6 +58,25 @@ contexts:
   url:
     - match: https?://\S+
       scope: markup.underline.link.debian
+
+  # Thu, 31 Dec 2020 16:54:06 +0100
+  date-iso:
+    - match: |-
+        (?x:
+          (?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)(,)[ ]
+          (?:\d{1,2})[ ]
+          (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ]
+          (?:(?:19|20)\d\d)[ ]
+          (?:\d\d(:)\d\d(?:(:)\d\d)?)?
+          (?:[ ]([+-])\d{4})?
+        )
+      scope: meta.number.date.debian.common
+             constant.numeric.debian.common
+      captures:
+        1: punctuation.separator.sequence.debian.common
+        2: punctuation.separator.sequence.debian.common
+        3: punctuation.separator.sequence.debian.common
+        4: keyword.operator.arithmetic.debian.common
 
   semantic-version:
     - match: |-

--- a/Syntaxes/debian-control.sublime-syntax
+++ b/Syntaxes/debian-control.sublime-syntax
@@ -6,24 +6,21 @@ file_extensions:
   - control
 scope: source.debian.control
 
-variables:
-  # https://www.debian.org/doc/debian-policy/ch-controlfields.html#source-package-control-files-debian-control
-  allowed_fields: |-
-    (?xi:
-       Source|Maintainer|Uploaders|Section|Priority|Build-Depends(?:-Arch|-Indep)?
-      |Build-Conflicts(?:-Arch|-Indep)?|Standards-Version|Homepage
-      |Vcs-(?:Browser|Arch|Bzr|Cvs|Darcs|Git|Hg|Mtn|Svn)|Testsuite|Rules-Requires-Root
-      |Package|Architecture|Essential|Depends|Pre-Depends|Recommends|Suggests|Breaks
-      |Conflicts|Provides|Replaces|Enhances|Description|Homepage|Built-Using|Package-Type
-    )
-
 contexts:
   main:
     - include: debian-common.sublime-syntax#comments
     - include: fields
 
+  # https://www.debian.org/doc/debian-policy/ch-controlfields.html#source-package-control-files-debian-control
   fields:
-    - match: ^({{allowed_fields}})(:)?
+    - match: |-
+        ^(?xi:
+          (Source|Maintainer|Uploaders|Section|Priority|Build-Depends(?:-Arch|-Indep)?
+            |Build-Conflicts(?:-Arch|-Indep)?|Standards-Version|Homepage
+            |Vcs-(?:Browser|Arch|Bzr|Cvs|Darcs|Git|Hg|Mtn|Svn)|Testsuite|Rules-Requires-Root
+            |Package|Architecture|Essential|Depends|Pre-Depends|Recommends|Suggests|Breaks
+            |Conflicts|Provides|Replaces|Enhances|Description|Homepage|Built-Using|Package-Type
+        ))(:)?
       captures:
         1: meta.mapping.key.debian keyword.control.debian.control
         2: punctuation.separator.mapping.key-value.debian.control
@@ -63,5 +60,4 @@ contexts:
         - match: (\))
           scope: punctuation.section.group.end.debian.control
           pop: true
-        - match: (?=\n)
-          pop: true
+        - include: debian-common.sublime-syntax#pop-eol

--- a/Syntaxes/debian-control.sublime-syntax
+++ b/Syntaxes/debian-control.sublime-syntax
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-# See http://www.sublimetext.com/docs/3/syntax.html
+# See http://www.sublimetext.com/docs/syntax.html
 name: control (Debian)
 file_extensions:
   - control
@@ -9,45 +9,59 @@ scope: source.debian.control
 variables:
   # https://www.debian.org/doc/debian-policy/ch-controlfields.html#source-package-control-files-debian-control
   allowed_fields: |-
-    (?i)^(
-      |Source|Maintainer|Uploaders|Section|Priority|Build-Depends(-Arch|-Indep)?|
-      |Build-Conflicts(-Arch|-Indep)?|Standards-Version|Homepage|
-      |Vcs-(Browser|Arch|Bzr|Cvs|Darcs|Git|Hg|Mtn|Svn)|Testsuite|Rules-Requires-Root|
-      |Package|Architecture|Essential|Depends|Pre-Depends|Recommends|Suggests|Breaks|
-      |Conflicts|Provides|Replaces|Enhances|Description|Homepage|Built-Using|Package-Type|
-    )
-
-  # https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#substvar
-  allowed_substvar: |-
-    (
-      |\${misc:Depends}|\${misc:Pre-Depends}|\${shlibs:Depends}|\${python:Depends}|
-      |\${python3:Depends}|\${perl:Depends}|\${ruby:Depends}|
+    (?xi:
+       Source|Maintainer|Uploaders|Section|Priority|Build-Depends(?:-Arch|-Indep)?
+      |Build-Conflicts(?:-Arch|-Indep)?|Standards-Version|Homepage
+      |Vcs-(?:Browser|Arch|Bzr|Cvs|Darcs|Git|Hg|Mtn|Svn)|Testsuite|Rules-Requires-Root
+      |Package|Architecture|Essential|Depends|Pre-Depends|Recommends|Suggests|Breaks
+      |Conflicts|Provides|Replaces|Enhances|Description|Homepage|Built-Using|Package-Type
     )
 
 contexts:
   main:
-    - include: comments
-    - include: email-address
+    - include: debian-common.sublime-syntax#comments
     - include: fields
-    - include: substvar
-
-  comments:
-    - match: "#"
-      scope: punctuation.definition.comment.debian
-      push:
-        - meta_scope: comment.line.debian
-        - match: \n
-          pop: true
-
-  email-address:
-    - match: <.+@.+[.].+>|<.+?at.+?dot.+?>
-      scope: variable.language.debian
 
   fields:
-    - match: '{{allowed_fields}}'
-      scope: keyword.control.debian
+    - match: ^({{allowed_fields}})(:)?
+      captures:
+        1: meta.mapping.key.debian keyword.control.debian.control
+        2: punctuation.separator.mapping.key-value.debian.control
+      push:
+        - meta_content_scope: meta.mapping.value.debian.control
+        - match: ^(?=\S)
+          pop: true
+        - include: substvar
+        - include: semver-flag
+        - include: debian-common.sublime-syntax#email-address
+        - include: debian-common.sublime-syntax#url
+        - match: \,|\|
+          scope: punctuation.separator.sequence.debian.control
 
+  # https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#substvar
   substvar:
-    - match: '{{allowed_substvar}}'
-      scope: variable.function.debian
+    - match: |-
+        (?x:
+          (\${)
+          (?:misc:Depends|misc:Pre-Depends|shlibs:Depends|python:Depends
+            |python3:Depends|perl:Depends|ruby:Depends)
+          (})
+        )
+      scope: variable.language.debian
+      captures:
+        1: punctuation.definition.variable.begin.debian.control
+        2: punctuation.definition.variable.end.debian.control
 
+  semver-flag:
+    - match: (?=\(>?=[ ]+\d(?:\.\d){0,2})
+      push:
+        - match: (\()(>?=)\s+
+          captures:
+            1: punctuation.section.group.begin.debian.control
+            2: keyword.operator.arithmetic.debian.control
+        - include: debian-common.sublime-syntax#semantic-version
+        - match: (\))
+          scope: punctuation.section.group.end.debian.control
+          pop: true
+        - match: (?=\n)
+          pop: true


### PR DESCRIPTION
I pulled some things into the utility class that can be reused for other syntaxes. Email identifiers are stolen and tweaked from the built-in Git syntaxes.

I didn't want to tweak any of the other syntax files until I knew what you thought of the changes here.